### PR TITLE
Add xpath collector and fix evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.13] - 2024-04-07
+
+- Add helper function to collect XPath mentioned inside an expression
+- Handle evaluation of NULL in comparison
+
 ## [1.0.12] - 2024-04-05
 
 - Add evaluation of date data types

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -50,7 +50,7 @@ Variables may be present in certain context of evaluation, they can be emulated 
 ```TypeScript
 import { evaluate } from '@adobe/acc-xtk-parser';
 
-const value1 = evaluate('@myattribute == 1', { variableConverter: (name) => // return your value});
+const value1 = evaluate('$(var1) == 1', { variableConverter: () => 1 }) // returns 1
 ```
 
 ## Match an Expression
@@ -70,4 +70,14 @@ const matched = pattern.match('@count = 1 AND @email IS NOT NULL');
 pattern.match('@count = 2 AND @email IS NOT NULL')
 // will raise a NoMatchFoundException exception
 
+```
+
+## Capture all xpath
+
+This feature is about collecting all xpath mentioned inside an expression.
+
+```TypeScript
+import { colcollectXPathlect } from '@adobe/acc-xtk-parser';
+
+const list = collectXPath('@path1 == @path2') // return ['@path1','@path2'];
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-xtk-parser",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Adobe Campaign XTK expression parser",
   "source": "src/index.ts",
   "main": "lib/main.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,6 +47,10 @@ export function isNumber(value: any) {
   return typeof value === 'number';
 }
 
+export function isNull(value: any) {
+  return value === null;
+}
+
 export function asInteger(value: boolean): number {
   return value ? 1 : 0;
 }

--- a/src/xpathCollector.ts
+++ b/src/xpathCollector.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { runXtkParser } from './parser';
+import XtkParserVisitor from './generated/XtkParserVisitor';
+import { XpathContext } from './generated/XtkParser';
+
+/**
+ * Collect all xpath mentioned in an expression
+ * @param {string} expr The XTK expression
+ * @returns {string[]} An array of xpath
+ */
+export function collectXPath(expr: string): string[] {
+  if (!expr) {
+    return [];
+  }
+  const ctx = runXtkParser(expr);
+  const evaluator = new XtkParserVisitor<void>();
+  const xpathList = [];
+  evaluator.visitXpath = (ctx: XpathContext): void => {
+    xpathList.push(ctx.getText());
+  };
+  ctx.accept(evaluator);
+  return xpathList;
+}

--- a/test/functionEvaluator.test.ts
+++ b/test/functionEvaluator.test.ts
@@ -13,6 +13,15 @@ governing permissions and limitations under the License.
 import { evaluate } from '../src/evaluator';
 
 describe('Test function evaluation', () => {
+  it('should manage functions', () => {
+    expect(() => evaluate("'abc' + func(@path)")).toThrow();
+    expect(evaluate("'abc' + func('value')", { functionConverter: (_, str) => str.toUpperCase() })).toEqual('abcVALUE');
+    expect(
+      evaluate("'abc' + func('value1','value2')", {
+        functionConverter: (_, str1, str2) => `${str1.toUpperCase()}${str2.toUpperCase()}`,
+      }),
+    ).toEqual('abcVALUE1VALUE2');
+  });
   it('should manage condition using functions', () => {
     expect(evaluate('f() AND g()', { functionConverter: (name) => (name === 'f' ? 1 : 0) })).toEqual(0);
     expect(evaluate('f() OR g()', { functionConverter: (name) => (name === 'f' ? 1 : 1) })).toEqual(1);

--- a/test/logicalEvaluator.test.ts
+++ b/test/logicalEvaluator.test.ts
@@ -78,4 +78,11 @@ describe('Test logical evaluator', () => {
   it('should manage precedence of AND over OR', () => {
     expect(evaluate('TRUE OR FALSE AND FALSE')).toEqual(1);
   });
+
+  it('should handle NULL', () => {
+    expect(evaluate('NULL = NULL')).toEqual(1);
+    expect(evaluate('NULL = 0')).toEqual(1);
+    expect(evaluate('NULL = 23')).toEqual(0);
+    expect(evaluate("NULL = 'ab'")).toEqual(0);
+  });
 });

--- a/test/stringEvaluator.test.ts
+++ b/test/stringEvaluator.test.ts
@@ -31,21 +31,7 @@ describe('Test string evaluator', () => {
     expect(evaluate("'abc' + 'def' + 'ghi'")).toEqual('abcdefghi');
     expect(evaluate("'abc' + 1")).toEqual('abc1');
   });
-  it('should manage xpath', () => {
-    expect(() => evaluate("'abc' + @path")).toThrow();
-    expect(evaluate("'abc' + @path", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpath');
-    expect(evaluate("'abc' + @path + @next", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpathnext');
-    expect(evaluate("'abc' + ( @path + @next )", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpathnext');
-  });
-  it('should manage functions', () => {
-    expect(() => evaluate("'abc' + func(@path)")).toThrow();
-    expect(evaluate("'abc' + func('value')", { functionConverter: (_, str) => str.toUpperCase() })).toEqual('abcVALUE');
-    expect(
-      evaluate("'abc' + func('value1','value2')", {
-        functionConverter: (_, str1, str2) => `${str1.toUpperCase()}${str2.toUpperCase()}`,
-      }),
-    ).toEqual('abcVALUE1VALUE2');
-  });
+
   it('should manage variables', () => {
     expect(() => evaluate("'abc' + $(var)")).toThrow();
     expect(evaluate("'abc' + $(var)", { variableConverter: () => 'VALUE' })).toEqual('abcVALUE');
@@ -57,6 +43,5 @@ describe('Test string evaluator', () => {
   it('should manage escaping and unicode', () => {
     expect(evaluate("'my\\'string\\''")).toEqual("my'string'");
     expect(evaluate("'çàaé'")).toEqual('çàaé');
-    expect(evaluate('@été', { xpathConverter: () => 'value' })).toBe('value');
   });
 });

--- a/test/xpathCollector.test.ts
+++ b/test/xpathCollector.test.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { collectXPath } from '../src/xpathCollector';
+
+describe('Test xpath collector', () => {
+  it('should not break when there is no path', () => {
+    expect(collectXPath('1 + 2 + 3')).toEqual([]);
+    expect(collectXPath('')).toEqual([]);
+  });
+  it('should manage to collect xpath in a basic operation', () => {
+    expect(collectXPath('@path1 + @path2')).toEqual(['@path1', '@path2']);
+  });
+  it('should manage to collect xpath wrapped in function call', () => {
+    expect(collectXPath('f(@path1) + f(g(@path2))')).toEqual(['@path1', '@path2']);
+  });
+});

--- a/test/xpathEvaluator.test.ts
+++ b/test/xpathEvaluator.test.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import { evaluate } from '../src/evaluator';
+
+describe('Test xpath evaluator', () => {
+  it('should manage xpath', () => {
+    expect(() => evaluate("'abc' + @path")).toThrow();
+    expect(evaluate("'abc' + @path", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpath');
+    expect(evaluate("'abc' + @path + @next", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpathnext');
+    expect(evaluate("'abc' + ( @path + @next )", { xpathConverter: (str) => str.substring(1) })).toEqual('abcpathnext');
+  });
+
+  it('should manage escaping and unicode in xpath', () => {
+    expect(evaluate('@été', { xpathConverter: () => 'value' })).toBe('value');
+  });
+
+  it('should manage xpath returning integer', () => {
+    expect(evaluate('@x + @y', { xpathConverter: (xpath) => (xpath === '@x' ? 2 : 3) })).toBe(5);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix evaluator when a xpath value is return as a number.
Add a collector of xpath.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
