### PR TITLE
Review input parameters of runXtkParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2024-10-21
+
+- Review parameters of runXtkParser, a listener can be now configured to catch errors (breaking change)
+
 ## [1.0.14] - 2024-04-08
 
 - Expose function collectXPath, disable expection of this function

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-xtk-parser",
-  "version": "1.0.14",
+  "version": "2.0.0",
   "description": "Adobe Campaign XTK expression parser",
   "source": "src/index.ts",
   "main": "lib/main.js",

--- a/src/xpathCollector.ts
+++ b/src/xpathCollector.ts
@@ -23,7 +23,7 @@ export function collectXPath(expr: string): string[] {
   if (!expr) {
     return [];
   }
-  const ctx = runXtkParser(expr, false);
+  const ctx = runXtkParser(expr, { exceptionOnError: false });
   const evaluator = new XtkParserVisitor<void>();
   const xpathList = [];
   evaluator.visitXpath = (ctx: XpathContext): void => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Review the input parameters of runXtkParser, enable passing a listener to get notified of errors during parsing.

## Related Issue

N/A

## Motivation and Context

Adobe internal requirements.

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
