### PR TITLE
Fix xpath not collected when used inside a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2024-11-21
+- Fix path not collected when inside a variable
+
 ## [2.1.0] - 2024-11-20
 - Add a preprocessing tool to replace variables inside expressions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-xtk-parser",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Adobe Campaign XTK expression parser",
   "source": "src/index.ts",
   "main": "lib/main.js",

--- a/src/xpathCollector.ts
+++ b/src/xpathCollector.ts
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 import { runXtkParser } from './parser';
 import XtkParserVisitor from './generated/XtkParserVisitor';
-import { XpathContext } from './generated/XtkParser';
+import { VariableIdentifierContext, XpathContext } from './generated/XtkParser';
 
 /**
  * Collect all xpath mentioned in an expression
@@ -28,6 +28,12 @@ export function collectXPath(expr: string): string[] {
   const xpathList = [];
   evaluator.visitXpath = (ctx: XpathContext): void => {
     xpathList.push(ctx.getText());
+  };
+  evaluator.visitVariableIdentifier = (ctx: VariableIdentifierContext): void => {
+    const variableName = ctx.getText();
+    if (variableName.startsWith('@')) {
+      xpathList.push(variableName);
+    }
   };
   ctx.accept(evaluator);
   return xpathList;

--- a/test/xpathCollector.test.ts
+++ b/test/xpathCollector.test.ts
@@ -23,6 +23,9 @@ describe('Test xpath collector', () => {
   it('should manage to collect xpath wrapped in function call', () => {
     expect(collectXPath('f(@path1) + f(g(@path2))')).toEqual(['@path1', '@path2']);
   });
+  it('should manage to collect xpath inside variables', () => {
+    expect(collectXPath('@path1 = $(@path2)')).toEqual(['@path1', '@path2']);
+  });
   it('should not break on errors', () => {
     expect(collectXPath('@value IS')).toEqual(['@value']);
     expect(collectXPath('+')).toEqual([]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix xpath not collected when used inside a variable

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
